### PR TITLE
get rid of `sync.Map` for better go version compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.9
+  - 1.8
 env:
   global:
     - TEST_TIMEOUT_SCALE=40


### PR DESCRIPTION
trying to resolve #7 to support Go 1.8
  